### PR TITLE
Fix: message queue overload

### DIFF
--- a/include/bag_launcher.h
+++ b/include/bag_launcher.h
@@ -106,6 +106,7 @@ namespace bag_launcher_node {
             double heartbeat_interval_;
             ros::Publisher name_publisher_;
             bool default_record_all_;
+            uint32_t queue_size_;
 
             std::map<std::string, std::shared_ptr<HeartBeat>> heartbeats_;
             std::map<std::string, std::shared_ptr<BagRecorder>> recorders_;

--- a/include/bag_recorder/bag_recorder.h
+++ b/include/bag_recorder/bag_recorder.h
@@ -113,6 +113,7 @@ namespace bag_recorder {
             bool                          recording_all_topics_;
             unsigned long long            min_recording_space_ = 1024 * 1024 * 1024;
             std::string                   min_recording_space_str_ = "1G";
+            uint64_t                      buffer_size_ = 1048576 * 256;
 
             //bag_ data
             rosbag::Bag                   bag_;
@@ -139,6 +140,8 @@ namespace bag_recorder {
             boost::condition_variable_any queue_condition_;
             boost::mutex                  queue_mutex_;
             std::queue<OutgoingMessage>*  message_queue_;                //!< queue for storing
+
+            uint64_t                      queue_size_ = 0;
 
             boost::thread                 record_thread_;
 

--- a/src/rosbag_recorder_node.cpp
+++ b/src/rosbag_recorder_node.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
     BagLauncher bag_launcher(nh, options);
 
     //main loop
-    ros::Rate r(200);
+    ros::Rate r(1000);
     while(ros::ok()) {
         //bag_launcher's loop function
         bag_launcher.check_all();


### PR DESCRIPTION
## Description

Drops old messages when the message queue overloads, to prevent the message queue from going to infinity when messages are coming in faster than we can pop them off the queue. 

Also does a bag duration check even when the queue is not empty so that the bag splitting happens even if there is a large queue of messages.

## Testing

Run and arm the drone with a large amount of logged messages. Check to see if there is eventually a "rosbag record buffer exceeded" printout (this will only happen if the messages are getting queued faster than getting logged). Also check that the bag splitting reliably happens for each minute. If that printout happens, you likely want to reduce the number of logged messages so that messages aren't getting dropped. 